### PR TITLE
Currency Fix

### DIFF
--- a/src/components/pages/Project.vue
+++ b/src/components/pages/Project.vue
@@ -176,6 +176,8 @@
                   </h4>
                   <currency-input
                     v-model="donationValue"
+                    :allow-negative="false"
+                    :auto-decimal-mode="true"
                     class="mt-3 headline"
                     @change="compareInput"
                   />


### PR DESCRIPTION
Currency-input wurde um erweitert um:
- keine negativen zahlen
- auto decimal Modus ist aktiviert

Der auto-decimal-mode ist meiner Meinung nach widerlich, aber so kann man auch Komma-Zahlen am Smartphone eingeben.
Bitte selbst mal ausprobieren und Rückmeldung geben!