### PR TITLE
Projektanlegen fix

### DIFF
--- a/src/components/pages/ProjektAnlegen.vue
+++ b/src/components/pages/ProjektAnlegen.vue
@@ -282,7 +282,7 @@
                           <v-col cols="12">
                             <v-text-field
                               v-model="editedItem.name"
-                              label="Meilensteinname"
+                              label="Meilensteinname*"
                               outlined
                               clearable
                               :rules="milestoneNameRule"
@@ -627,8 +627,8 @@ export default {
       const [day, month, year] = copy.until.split('.');
       copy.until = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
 
-      this.editedItem = copy;
-      this.preEditedItem = copy;
+      this.editedItem = { ...copy };
+      this.preEditedItem = { ...copy };
       this.deleteItem(item);
       this.dialog2 = true;
     },

--- a/src/components/pages/ProjektAnlegen.vue
+++ b/src/components/pages/ProjektAnlegen.vue
@@ -320,7 +320,7 @@
                         Cancel
                       </v-btn>
                       <v-btn
-                        :disabled="editedItem.name === '' || editedItem.goal === '' || editedItem.until === null"
+                        :disabled="editedItem.name === null || editedItem.goal === null || editedItem.until === null"
                         color="blue darken-1"
                         text
                         @click="save"


### PR DESCRIPTION
ein paar kleine Sachen zum dialogfenster beim erstellen eines weiteren Meilensteines.
-bei cancel wurde nicht richtig auf den vorherigen stand zurückgekehrt.
-bei save konnte titel und Wei weggelassen werden, nur datum war nötig, um save button zu enablen.