### PR TITLE
Spendenseite kleine Fixes 

### DIFF
--- a/src/components/elements/Navbar.vue
+++ b/src/components/elements/Navbar.vue
@@ -519,6 +519,7 @@
 import * as blockstack from 'blockstack';
 import axios from 'axios';
 import { userSession } from '@/userSession';
+import EventBus from '@/utils/eventBus';
 
 export default {
   name: 'Navbar',
@@ -568,6 +569,9 @@ export default {
         this.$refs.register_form.validate();
       }
     }, 250);
+    EventBus.$on('reload-user', () => {
+      this.get_user();
+    });
   },
   methods: {
     signIn() {

--- a/src/components/pages/Project.vue
+++ b/src/components/pages/Project.vue
@@ -361,6 +361,8 @@ export default {
         axios.post('donations', {}, { headers })
           .then(() => {
             this.openDialog();
+            this.loadProject();
+            EventBus.$emit('reload-user');
           })
           .catch((err) => {
             EventBus.$emit('new-snackbar', `Spende konnte nicht getätigt werden: ${err.toString()}`, 'error', 10000, true);
@@ -377,7 +379,6 @@ export default {
     closeDialog() {
       this.dialog = false;
       this.$confetti.stop();
-      window.location.reload(true);
     },
     weiToEuro() {
       this.loading = true;

--- a/src/components/pages/Project.vue
+++ b/src/components/pages/Project.vue
@@ -296,7 +296,7 @@ export default {
     weiFormula: 1e18,
     errorMessage: null,
     loading: false,
-    voteEnabled: true,
+    voteEnabled: false,
     voteDisabled: true,
     donationDisabled: true,
     apiurl: window.apiurl,
@@ -361,7 +361,6 @@ export default {
         axios.post('donations', {}, { headers })
           .then(() => {
             this.openDialog();
-            this.loadProject();
           })
           .catch((err) => {
             EventBus.$emit('new-snackbar', `Spende konnte nicht getätigt werden: ${err.toString()}`, 'error', 10000, true);
@@ -378,6 +377,7 @@ export default {
     closeDialog() {
       this.dialog = false;
       this.$confetti.stop();
+      window.location.reload(true);
     },
     weiToEuro() {
       this.loading = true;

--- a/src/components/pages/ProjectGutschein.vue
+++ b/src/components/pages/ProjectGutschein.vue
@@ -312,6 +312,7 @@ export default {
           .then(() => {
             this.boughtVoucher = voucher;
             this.openDialog();
+            EventBus.$emit('reload-user');
           })
           .catch((err) => {
             EventBus.$emit('new-snackbar', `Gutschein konnte nicht gekauft werden ${err.toString()}`, 'error', 10000, true);


### PR DESCRIPTION
Issue #211 
Checkbox nicht standardmäßig ausgewählt.
Das Neuladen der Seite (wie vorgeschlagen)  habe ich erstmal beim Schließen der Konfetti Animation gemacht. Allerdings wirkt das so sehr abgehackt. Ich finde es fühlt sich ohne reload eindeutig besser an, auch wenn dann das ether der Navbar nicht aktualisiert wird.